### PR TITLE
Update `Expat` to version `2.4.4`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 14c58c2a0b5b8b31836514dfab41bd191836db7aa7b84ae5c47bc0327a20d64a
 
 build:
-  number: 2
+  number: 0
   run_exports:
     # changes soname at major versions, default settings OK
     # https://abi-laboratory.pro/tracker/timeline/expat/
@@ -31,12 +31,13 @@ test:
     - xmlwf -h
 
 about:
-  home: http://expat.sourceforge.net/
+  home: https://expat.sourceforge.net/
   license: MIT
   license_family: MIT
   license_file: COPYING
   summary: 'Expat XML parser library in C'
   dev_url: https://github.com/libexpat/libexpat
+  doc_url: https://github.com/libexpat/libexpat/tree/master/expat/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
     - xmlwf -h
 
 about:
-  home: https://expat.sourceforge.net/
+  home: http://expat.sourceforge.net/
   license: MIT
   license_family: MIT
   license_file: COPYING

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.1" %}
+{% set version = "2.4.4" %}
 {% set ver = version|replace(".", "_") %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/libexpat/libexpat/releases/download/R_{{ ver }}/expat-{{ version }}.tar.bz2
-  sha256: 2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40
+  sha256: 14c58c2a0b5b8b31836514dfab41bd191836db7aa7b84ae5c47bc0327a20d64a
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ about:
   home: http://expat.sourceforge.net/
   license: MIT
   license_family: MIT
-  license_file: COPYING
+  license_file: expat/COPYING
   summary: 'Expat XML parser library in C'
   dev_url: https://github.com/libexpat/libexpat
   doc_url: https://github.com/libexpat/libexpat/tree/master/expat/doc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,10 +31,11 @@ test:
     - xmlwf -h
 
 about:
-  home: http://expat.sourceforge.net/
+  home: https://libexpat.github.io
   license: MIT
   license_family: MIT
-  license_file: expat/COPYING
+  # Note that the file is in a subdirectory expat/COPYING the expat is in a subdirectory
+  license_file: COPYING
   summary: 'Expat XML parser library in C'
   dev_url: https://github.com/libexpat/libexpat
   doc_url: https://github.com/libexpat/libexpat/tree/master/expat/doc


### PR DESCRIPTION
  `expat` version `2.4.4`
1. - [x] check the upstream

https://github.com/libexpat/libexpat/tree/R_2_4_4

2. - [x] check the pinnings

https://github.com/libexpat/libexpat/blob/R_2_4_4/appveyor.yml
https://github.com/libexpat/libexpat/blob/R_2_4_4/expat/Changes
https://github.com/libexpat/libexpat/blob/R_2_4_4/expat/CMakeLists.txt
https://github.com/libexpat/libexpat/blob/R_2_4_4/expat/CMake.README

3. - [x] check the changelogs

https://github.com/libexpat/libexpat/blob/R_2_4_4/expat/Changes

The changes mentioned in the `changelogs` were mainly bug fixes

4. - [x] additional research

    https://github.com/conda-forge/expat-feedstock/issues

    There were no open issues mentioned in `conda-forge` at the time of the review 

5. - [x] verify dev_url
    https://github.com/libexpat/libexpat

6. - [x] verify doc_url
    No `doc_url` was provided so the following location was given

    https://github.com/libexpat/libexpat/tree/master/expat/doc

7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number

    The build number was set to zero

10. - [x] verify setuptools

      `setuptools` is not a dependency in the package

11. - [x] verify wheel

`wheel` is not a dependency in the package

12. - [x] pip in the test section
13. - [x] veriy the test section

Results:
- All checks have passed


Based on the research findings and the results we can conclude
that it is safe to update `expat` to version `2.4.4`

