### PR TITLE
Update from 2.4.4 to 2.4.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/libexpat/libexpat/releases/download/R_{{ ver }}/expat-{{ version }}.tar.bz2
-  sha256: 7f44d1469b110773a94b0d5abeeeffaef79f8bd6406b07e52394bcf4812643…
+  sha256: 7f44d1469b110773a94b0d5abeeeffaef79f8bd6406b07e52394bcf48126437a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.4" %}
+{% set version = "2.4.9" %}
 {% set ver = version|replace(".", "_") %}
 
 package:
@@ -34,11 +34,12 @@ about:
   home: https://libexpat.github.io
   license: MIT
   license_family: MIT
-  # Note that the file is in a subdirectory expat/COPYING the expat is in a subdirectory
   license_file: COPYING
-  summary: 'Expat XML parser library in C'
+  license_url: https://github.com/libexpat/libexpat/blob/master/expat/COPYING
+  summary: Expat XML parser library in C
   dev_url: https://github.com/libexpat/libexpat
-  doc_url: https://github.com/libexpat/libexpat/tree/master/expat/doc
+  doc_url: https://libexpat.github.io/doc/
+  doc_source_url: https://github.com/libexpat/libexpat/tree/master/expat/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/libexpat/libexpat/releases/download/R_{{ ver }}/expat-{{ version }}.tar.bz2
-  sha256: 14c58c2a0b5b8b31836514dfab41bd191836db7aa7b84ae5c47bc0327a20d64a
+  sha256: 7f44d1469b110773a94b0d5abeeeffaef79f8bd6406b07e52394bcf4812643…
 
 build:
   number: 0


### PR DESCRIPTION
Jira:
- https://anaconda.atlassian.net/browse/PKG-41

Changes:
- Set to 2.4.9
- Update about section

Change log: https://github.com/libexpat/libexpat/blob/master/expat/Changes
Changes 2.4.4 -> 4.4.9 : https://github.com/libexpat/libexpat/compare/R_2_4_4...R_2_4_9
https://libexpat.github.io
https://github.com/libexpat/libexpat

CVE fixes included:
- CVE-2022-40674
- CVE-2022-25236
- CVE-2022-25235
- CVE-2022-25313
- CVE-2022-25314
- CVE-2022-25315

Relax expat pinning on aggregate:
https://github.com/AnacondaRecipes/aggregate/pull/235