### PR TITLE
update to 2.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.5.0" %}
+{% set version = "2.6.2" %}
 {% set ver = version|replace(".", "_") %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/libexpat/libexpat/releases/download/R_{{ ver }}/expat-{{ version }}.tar.bz2
-  sha256: 6f0e6e01f7b30025fa05c85fdad1e5d0ec7fd35d9f61b22f34998de11969ff67
+  sha256: 9c7c1b5dcbc3c237c500a8fb1493e14d9582146dd9b42aa8d3ffb856a3b927e0
 
 build:
   number: 0


### PR DESCRIPTION
expat 2.6.2

**Destination channel:** main
### Links

- [PKG-4465](https://anaconda.atlassian.net/browse/PKG-4465) 
- [Upstream repository](https://github.com/libexpat/libexpat/tree/R_2_6_2)
- [Upstream changelog/diff](https://github.com/libexpat/libexpat/blob/R_2_6_2/expat/Changes)

### Explanation of changes:

- Update to 2.6.2.
- Packages depending on expat have upper bound set to `<3`.  No breaking changes from 2.5.0 to 2.6.2.
- Reason: https://anaconda.atlassian.net/browse/CVE-774


[PKG-4465]: https://anaconda.atlassian.net/browse/PKG-4465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ