### PR TITLE
expat 2.6.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.6.2" %}
+{% set version = "2.6.3" %}
 {% set ver = version|replace(".", "_") %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/libexpat/libexpat/releases/download/R_{{ ver }}/expat-{{ version }}.tar.bz2
-  sha256: 9c7c1b5dcbc3c237c500a8fb1493e14d9582146dd9b42aa8d3ffb856a3b927e0
+  sha256: b8baef92f328eebcf731f4d18103951c61fa8c8ec21d5ff4202fb6f2198aeb2d
 
 build:
   number: 0
@@ -36,7 +36,7 @@ about:
   summary: Expat XML parser library in C
   description: |
     Expat is a stream-oriented XML parser library written in C.
-    Expat excels with files too large to fit RAM, and where performance 
+    Expat excels with files too large to fit RAM, and where performance
     and flexibility are crucial.
   dev_url: https://github.com/libexpat/libexpat
   doc_url: https://libexpat.github.io/doc/


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5658](https://anaconda.atlassian.net/browse/PKG-5658) 
- [Upstream repository](https://github.com/libexpat/libexpat/tree/R_2_6_3)
- Changelog: https://github.com/libexpat/libexpat/blob/R_2_6_3/expat/Changes#L33-L85

### Explanation of changes:

- No changes

### Notes:

- To address CVEs: CVE-2024-45490, CVE-2024-45491, CVE-2024-45492
- See also https://github.com/python/cpython/issues/123678

[PKG-5658]: https://anaconda.atlassian.net/browse/PKG-5658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ