### PR TITLE
v2.7.5

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,13 +3,6 @@ set LIB=%LIBRARY_LIB%;%LIB%
 set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%
 
-:: VS2008 doesn't have stdbool.h so copy in our own
-:: to 'lib' where the other headers are so it gets picked up.
-if "%VS_MAJOR%" == "9" (
-    copy %RECIPE_DIR%\stdbool.h lib\
-    copy %LIBRARY_INC%\stdint.h lib\
-)
-
 :: set cflags because NDEBUG is set in Release configuration, which errors out in test suite due to no assert
 cmake -G "Ninja" ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "expat" %}
-{% set version = "2.7.4" %}
+{% set version = "2.7.5" %}
 
 package:
   name: {{ name }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/lib{{ name }}/lib{{ name }}/releases/download/R_{{ version|replace(".", "_") }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: e6af11b01e32e5ef64906a5cca8809eabc4beb7ff2f9a0e6aabbd42e825135d0
+  sha256: 386a423d40580f1e392e8b512b7635cac5083fe0631961e74e036b0a7a830d77
 
 build:
   number: 0

--- a/recipe/stdbool.h
+++ b/recipe/stdbool.h
@@ -1,3 +1,0 @@
-typedef int bool;
-#define false 0
-#define true 1


### PR DESCRIPTION
expat v2.7.5

**Destination channel:**  defaults

### Links

- [PKG-13179](https://anaconda.atlassian.net/browse/PKG-13179) 
- [Upstream repository](https://github.com/libexpat/libexpat/tree/R_2_7_5)
- [Upstream changelog/diff](https://github.com/libexpat/libexpat/blob/R_2_7_5/expat/Changes)


### Explanation of changes:

- Bump version and SHA
- Remove old work around from bld.bat

### Notes
- This release addresses three CVEs: CVE-2026-32776, CVE-2026-32777, CVE-2026-32778


[PKG-13179]: https://anaconda.atlassian.net/browse/PKG-13179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ