### PR TITLE
expat 2.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "expat" %}
-{% set version = "2.7.5" %}
+{% set version = "2.8.0" %}
 
 package:
   name: {{ name }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/lib{{ name }}/lib{{ name }}/releases/download/R_{{ version|replace(".", "_") }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: 386a423d40580f1e392e8b512b7635cac5083fe0631961e74e036b0a7a830d77
+  sha256: 586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-14027](https://anaconda.atlassian.net/browse/PKG-14027)
- [Upstream repository](https://github.com/libexpat/libexpat/tree/R_2_8_0)
- [Upstream changelog/diff](https://github.com/libexpat/libexpat/blob/R_2_8_0/expat/Changes)

### Explanation of changes:

- Bump version and sha256
- Fixes CVE-2026-41080


[PKG-14027]: https://anaconda.atlassian.net/browse/PKG-14027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ