### PR TITLE
Update version to 2.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "expat" %}
-{% set version = "2.8.0" %}
+{% set version = "2.8.1" %}
 
 package:
   name: {{ name }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/lib{{ name }}/lib{{ name }}/releases/download/R_{{ version|replace(".", "_") }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: 586494499ac3ad46d87f3beda7b1f770c1c8026a9b60e151593f8b29089a52ca
+  sha256: f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb
 
 build:
   number: 0


### PR DESCRIPTION
expat 2.8.1

**Destination channel:**  defaults

### Links

- [PKG-14745](https://anaconda.atlassian.net/browse/PKG-14745) 
- [Upstream repository](https://github.com/libexpat/libexpat/tree/R_2_8_1)
### Explanation of changes:
- New version number


[PKG-14745]: https://anaconda.atlassian.net/browse/PKG-14745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ